### PR TITLE
Changes login api to call rawPost instead of normal post that goes th…

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,15 +1,14 @@
 import Api from '../services/api';
 import { removeCookie, setCookie, getCookie } from '../utils/cookie';
 
+const contentTypeJson = { 'Content-Type': 'application/json' };
+
 export const login = async(data) => {
   if (!Object.keys(data).length) {
     return;
   }
 
-  const config = {
-    'Content-Type': 'application/json',
-  }
-  const result = await Api.post(`login`, data, config);
+  const result = await Api.rawPost(`login`, data, contentTypeJson);
   if (result) {
     setCookie(result)
   }
@@ -21,11 +20,7 @@ export const adminLogin = async(data) => {
     return;
   }
 
-  const config = {
-    'Content-Type': 'application/json',
-  }
-
-  const result = await Api.post(`adminlogin`, data, config);
+  const result = await Api.rawPost(`adminlogin`, data, contentTypeJson);
 
   if (result) {
     setCookie(result)
@@ -44,6 +39,6 @@ export const verifyAuth = () => {
 }
 
 export const verifyUser = () => {
-  let {token, userRole} = getCookie();
+  let { token } = getCookie();
   return !!token;
 }


### PR DESCRIPTION
Changes login api to call rawPost instead of normal post that goes through products formatFormData, which does not make any sense.  Right now, any Api.post goest through that formatFormData which seems to be specific to product, under ../utils/products.  I guess it might be used for other things, but this does not seem right.

This only changes the login piece.  This way login on the server side does not need to use multer (which is mostly used for parsing file) in order to get the json from request.body.  This requires some changes on the server side first.