### PR TITLE
Next redux wrapper supposedly correct implementation of redux store for NextJs

### DIFF
--- a/src/pages/_app.js
+++ b/src/pages/_app.js
@@ -2,11 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import NextApp from 'next/app'
 import React from 'react'
 import '../../styles.scss'
-// import { ThemeProvider } from 'styled-components'
-
-import { Provider } from 'react-redux';
-import withRedux from 'next-redux-wrapper';
-import store from '../redux/store';
+import { wrapper } from '../redux/store';
 import { appWithTranslation } from '../../i18n';
 
 class App extends NextApp {
@@ -18,12 +14,9 @@ class App extends NextApp {
   render() {
     const { Component, pageProps } = this.props
     return (
-      <Provider store={store}>
         <Component {...pageProps} />
-      </Provider>
     )
   }
 }
 
-const makeStore = () => store;
-export default withRedux(makeStore)(appWithTranslation(App))
+export default wrapper.withRedux(appWithTranslation(App))

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,19 +1,10 @@
 import { createStore, applyMiddleware } from 'redux';
+import { createWrapper } from 'next-redux-wrapper';
 import rootReducer from './reducers/rootReducer';
 import thunk from 'redux-thunk';
 
-const logger = ({ getState }) => {
-    return next => action => {
-        console.log('will dispatch', action);
-
-        const returnValue = next(action);
-
-        console.log('state after dispatch', getState());
-
-        return returnValue;
-    }
+const makeStore = (context) => {
+    return createStore(rootReducer, applyMiddleware(thunk));
 }
 
-const store = createStore(rootReducer, applyMiddleware(thunk, logger));
-
-export default store;
+export const wrapper = createWrapper(makeStore, { debug: true });


### PR DESCRIPTION
This is supposedly  the correct implementation for the nextjs redux wrapper, I think.  Just did a small test on the main website.  I don't see the "You are using legacy implementaion. Please update your code: use createWrapper() and wrapper.withRedux()"  error anymore.