### PR TITLE
AV-128-b: Explicit places where it asks for thumbnail are replaced by…

### DIFF
--- a/src/pages/account/vendor/products.js
+++ b/src/pages/account/vendor/products.js
@@ -9,12 +9,10 @@ import {
 } from '@material-ui/core';
 
 import VendorLayoutTemplate from '../../../components/common/Layout/VendorLayoutTemplate';
-import ItemForm from '../../../components/common/Form/ItemForm';
 import { noImageUrl } from '../../../../config'; 
 import { deleteItem, getItems, getItemByFkId } from '../../../api';
-import Icons from '../../../components/common/Icons';
 import ProgressBar from '../../../components/common/ProgressBar';
-import Snackbar from '../../../components/common/Snackbar';
+import { getThumbnail } from '../../../utils/helpers/image'
 
 const styles = (theme) => ({
   root: {
@@ -134,8 +132,6 @@ const Products = ({classes, userInfo, vendorInfo}) => {
   }
 
   const loadVendorProducts = async() => {
-    let sect = null;
-    let getItemResult = null;
     try {
       const getItemResult = await getItemByFkId('products', 'productsvendor', vendorInfo.id);
       setProducts(getItemResult);
@@ -156,7 +152,7 @@ const Products = ({classes, userInfo, vendorInfo}) => {
         {
           showData ? products.length ? products.map((product, index) => {
             let imageUrl = product.productImages && product.productImages.length ? (
-              <img src={`${process.env.IMAGE_URL}/${product.productImages[0].img_url}`} className={`img-fluid`} alt={product.name} />
+              <img src={`${process.env.IMAGE_URL}/${getThumbnail(product.productImages[0])}`} className={`img-fluid`} alt={product.name} />
             ) : (
               <img src={`${noImageUrl.img}`} className={`img-fluid`} alt={noImageUrl.alt} />
             )

--- a/src/pages/product/[pid].js
+++ b/src/pages/product/[pid].js
@@ -41,6 +41,7 @@ import VendorBox from '../../components/vendorBox';
 import { getDisplayName } from 'next/dist/next-server/lib/utils';
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { getThumbnail } from '../../utils/helpers/image'
 
 const styles = (theme) => ({
   root: {
@@ -280,14 +281,14 @@ const Index = ({classes, data = ProductSample, cart, updateCart, addCart}) => {
         imgs = data.productImages.map((img) => {
           return {
             original: `${imageUrl}/${img.img_url}`,
-            thumbnail: `${imageUrl}/${img.img_url}`,
+            thumbnail: `${imageUrl}/${getThumbnail(img)}`,
           }
         });
       } else if (productInfo.productImages && productInfo.productImages.length) {
         imgs = productInfo.productImages.map((img) => {
           return {
             original: `${imageUrl}/${img.img_url}`,
-            thumbnail: `${imageUrl}/${img.img_url}`,
+            thumbnail: `${imageUrl}/${getThumbnail(img)}`,
           }
         });
       } else {

--- a/src/pages/product/questions/[pid].js
+++ b/src/pages/product/questions/[pid].js
@@ -13,6 +13,7 @@ import { ADMIN_SECTIONS } from '../../../constants/admin';
 import { sendQuestion, getQuestionById } from '../../../api/questions';
 import { getItemById } from '../../../api';
 import AnswerProductQuestionsForm from '../../../components/common/AnswerProductQuestionsForm';
+import { getThumbnail } from '../../../utils/helpers/image'
 
 const styles = (theme) => ({
   root: {
@@ -57,7 +58,7 @@ const Index = ({classes, data}) => {
     const imgs = data.productImages.map((img) => {
         return {
           original: `${imageUrl}/${img.img_url}`,
-          thumbnail: `${imageUrl}/${img.img_url}`,
+          thumbnail: `${imageUrl}/${getThumbnail(img)}`,
         }
     });
     setImages(imgs);

--- a/src/pages/product/review/create/[pid].js
+++ b/src/pages/product/review/create/[pid].js
@@ -10,6 +10,7 @@ import { getImageUrlByType } from '../../../../utils/form';
 import AddForm from '../../../../components/common/Form/AddForm';
 import { MAIN_SECTIONS } from '../../../../constants';
 import { getItemById } from '../../../../api';
+import { getThumbnail } from '../../../../utils/helpers/image'
 
 const styles = (theme) => ({
   root: {
@@ -36,7 +37,7 @@ const Index = ({classes, data}) => {
     const imgs = data.productImages.map((img) => {
         return {
           original: `${imageUrl}/${img.img_url}`,
-          thumbnail: `${imageUrl}/${img.img_url}`,
+          thumbnail: `${imageUrl}/${getThumbnail(img)}`,
         }
     });
     setImages(imgs);

--- a/src/utils/helpers/image/index.js
+++ b/src/utils/helpers/image/index.js
@@ -1,0 +1,4 @@
+/** Returns the thumbnail image key if exist or defaults to normal image */
+export const getThumbnail = (obj) => {
+    return obj.img_thumb_url ? obj.img_thumb_url : obj.img_url;
+}


### PR DESCRIPTION
… the thumbnail key(url)

@luishk807 Only the places where it has an explicit field name of **thumbnail** was replaced with the **img_thumb_url** field through **getThumbnail** helper.  The helper will return **img_url** when the thumbnail is not available.  Since I don't know whether the other places that refers to **img_url** should be thumbnails, you'll have to implement it on the places where you know  they should be using the thumbnail instead.