### PR TITLE
AV-181: Hide rating stars using a global setting in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -697,6 +697,10 @@ export const IGNORE_FORM_FIELDS = ['useDate', 'saved'];
 
 export const ALLOW_FIELDS = ['saved', 'id', 'items', 'totalSaved', 'paymentOptionId', 'deliveryOptionId', 'deliveryServiceId', 'promotionCodeId', 'promotionCode'];
 
+const SYSTEM_CONFIGS = {
+  enableRating: false
+}
+
 export const config = {
   backEndUrl: process.env.BACKEND_URL,
   apiBaseUrl: process.env.API_BASE_URL,
@@ -714,5 +718,6 @@ export const config = {
   },
   web: 'www.avenidaz.com',
   address: 'Plaza Dorado',
-  adminRoles: [1,3]
+  adminRoles: [1,3],
+  system: SYSTEM_CONFIGS
 }

--- a/src/components/common/Rate/Rate.jsx
+++ b/src/components/common/Rate/Rate.jsx
@@ -9,6 +9,7 @@ import Typography from '../Typography';
 
 import { RateLabels } from '../../../../config';
 import { useEffect, useState } from 'react';
+import { config } from '../../../../config';
 
 const styles = (theme) => ({
   root: {
@@ -39,22 +40,26 @@ const Rate = ({className, classes, data, onChange, onChangeActive, disabled = fa
     onChange(value)
   }
 
-  return (
-    <div className={classes.root}>
-      <Rating
-        name="user-feedback"
-        value={rate}
-        precision={0.5}
-        className={className}
-        disabled={disabled}
-        onChange={handleOnChange}
-        onChangeActive={onChangeActive}
-      />
-      {
-        showTitle && (<Typography component="div" className={classes.rateLabel}>{RateLabels[rate]}</Typography>)
-      }
-    </div>
-  );
+  if (config.system && config.system.enableRating) {
+    return (
+      <div className={classes.root}>
+        <Rating
+          name="user-feedback"
+          value={rate}
+          precision={0.5}
+          className={className}
+          disabled={disabled}
+          onChange={handleOnChange}
+          onChangeActive={onChangeActive}
+        />
+        {
+          showTitle && (<Typography component="div" className={classes.rateLabel}>{RateLabels[rate]}</Typography>)
+        }
+      </div>
+    );
+  } else {
+    return <></>
+  }
 }
 
 Rate.protoTypes = {


### PR DESCRIPTION
Added a global **enableRating** setting in application's config.js file to enable and disable rating.  When it is disable, the component will just not render.