### PR TITLE
Fix: RadioBox.jsx crash due to empty options (empty array)

### DIFF
--- a/src/components/common/RadioBox.jsx
+++ b/src/components/common/RadioBox.jsx
@@ -109,10 +109,12 @@ const RadioBox = React.memo(({
     let data = null;
     let useSelected = selected;
     if (type === "address") {
-      let getFav = options.filter(item => item.selected === true);
-      data = getFav ? getFav[0].id : options[0].id;
-      if (!useSelected) {
-        useSelected = data;
+      if (!!options.length) {
+        let getFav = options.filter(item => item.selected === true);
+        data = !!getFav.length ? getFav[0].id : options[0].id;
+        if (!useSelected) {
+          useSelected = data;
+        }
       }
     } 
 


### PR DESCRIPTION
@luishk807 please review this to see if there are impact in other places that this component is used.  The change was only checking that there are items in *options* array before trying to "getFav" (I guess it is get favorite).

This crash was occurring in checkout when you hit cancel on addresses, and then you want to click back change address and it will crash because there are no address options to show.